### PR TITLE
test_helper.rb now works on clean pull.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Gemfile.lock
 
 # The db directory is used by the test suite to verify the rankle install generator
 /db
+/bin

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -13,12 +13,14 @@ ActiveRecord::Base.establish_connection(
 rake = Rake.application
 rake.init
 rake.load_rakefile
-Dir.entries(File.dirname(__FILE__) + '/../../db/migrate').each do |filename|
-  File.delete(File.dirname(__FILE__) + '/../../db/migrate/' + filename) rescue nil
+
+[File.dirname(__FILE__) + '/../../db/migrate',
+ 'rankle.sqlite3'].each do |path|
+  FileUtils::rm_rf(path) if File.exist?(path)
 end
+
 Rails::Generators.invoke 'rankle:install'
 require File.dirname(__FILE__) + '/../../db/migrate/' + Dir.entries(File.dirname(__FILE__) + '/../../db/migrate').sort.last
-File.delete 'rankle.sqlite3'
 CreateRankleIndices.new.migrate :up
 
 load File.dirname(__FILE__) + '/schema.rb'


### PR DESCRIPTION
The prior code presumed the db/ dir and rankle.sqlite3 files would
exist, but then blow up if they didn't. This should fix that.
